### PR TITLE
Log on processes having suspicious memory usage

### DIFF
--- a/include/system_monitor.hrl
+++ b/include/system_monitor.hrl
@@ -40,14 +40,14 @@
         , dreductions         :: integer()
         , dmemory             :: integer()
         , reductions          :: integer()
-        , memory              :: integer()
+        , memory              :: integer() %% bytes
         , message_queue_len   :: integer()
         , current_function    :: mfa()
         , initial_call        :: mfa()
         , registered_name     :: atom()
         , stack_size          :: integer()
-        , heap_size           :: integer()
-        , total_heap_size     :: integer()
+        , heap_size           :: integer() %% words
+        , total_heap_size     :: integer() %% words
         , current_stacktrace  :: list()
         , group_leader        :: list()
         }).

--- a/src/system_monitor.app.src
+++ b/src/system_monitor.app.src
@@ -72,5 +72,8 @@
        , {long_gc, 500}
        , {long_schedule, 500}
        ]}
+    , {suspect_procs_max_memory, 524288000} %% 500 MB
+    , {suspect_procs_max_message_queue_len, 5000}
+    , {suspect_procs_max_total_heap_size, 524288000} %% 500 MB
     ]}
  ]}.

--- a/src/system_monitor_top.erl
+++ b/src/system_monitor_top.erl
@@ -30,7 +30,7 @@
 %% API
 -export([start_link/0, get_app_top/0, get_abs_app_top/0,
          get_app_memory/0, get_app_processes/0,
-         get_function_top/0, get_proc_top/0]).
+         get_function_top/0, get_proc_top/0, get_proc_top/1]).
 
 %% gen_server callbacks
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
@@ -85,6 +85,16 @@
 get_proc_top() ->
   {ok, Data} = gen_server:call(?SERVER, get_proc_top, infinity),
   Data.
+
+
+%%--------------------------------------------------------------------
+%% @doc
+%% Get Erlang process top info for one process
+%% @end
+%%--------------------------------------------------------------------
+-spec get_proc_top(pid()) -> #erl_top{} | false.
+get_proc_top(Pid) ->
+  gen_server:call(?SERVER, {get_proc_top, Pid}, infinity).
 
 %%--------------------------------------------------------------------
 %% @doc
@@ -169,6 +179,9 @@ handle_call(get_proc_top, _From, State) ->
   SnapshotTS = State#state.last_ts,
   Data = {SnapshotTS, Top},
   {reply, {ok, Data}, State};
+handle_call({get_proc_top, Pid}, _From, State) ->
+  Top = State#state.proc_top,
+  {reply, lists:keyfind(pid_to_list(Pid), #erl_top.pid, Top), State};
 handle_call(get_app_top, _From, State) ->
   Data = State#state.app_top,
   {reply, {ok, Data}, State};


### PR DESCRIPTION
During an issue we experienced, lots of processes were consuming lots of memory however we did not get this information. The data is pushed to Kafka but Kafka had issues at the time and hence we missed vital information for debugging. It'll be nice to log some suspicious memory usage rather than relying on the push for Kafka to at least get some information in times of crisis. 