### PR TITLE
system_monitor_top: avoid divide by zero during init

### DIFF
--- a/src/system_monitor_top.erl
+++ b/src/system_monitor_top.erl
@@ -568,11 +568,11 @@ top_to_list({_, Top}) ->
 delta(P1, P2, Dt) ->
   case P1 of
     undefined ->
-      DRed = P2#pid_info.reductions / Dt,
-      DMem = P2#pid_info.memory / Dt;
+      DRed = divide(P2#pid_info.reductions, Dt),
+      DMem = divide(P2#pid_info.memory, Dt);
     _ ->
-      DRed = (P2#pid_info.reductions - P1#pid_info.reductions) / Dt,
-      DMem = (P2#pid_info.memory - P1#pid_info.memory) / Dt
+      DRed = divide((P2#pid_info.reductions - P1#pid_info.reductions), Dt),
+      DMem = divide((P2#pid_info.memory - P1#pid_info.memory), Dt)
   end,
   P2#pid_info
     { dreductions = DRed


### PR DESCRIPTION
During init, system_monitor_top send itself a collect_data message and records the current time stamp in last_ts. The handler for collect_data retrieves the current time stamp, computes the diff from last_ts, and divides measurement diffs by this time diff. If the initial time diff is zero, the gen_server crashes with a badarith in delta/3.

I've seen this happen several times with OTP-24.0 and system_monitor @ 8c60942f445. Current master changed to a different time stamp source which seems to have higher precision in my environment (Linux x86_64), making the bug difficult to provoke. However, the logic remains the same and I believe the bug can still occur.

The fix is to replace a few raw division operators with calls to divide/2.