### PR TITLE
only enable report_full_status monitor if callback_mod is defined

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,8 +106,10 @@ System_monitor will spawn several processes that handle different states:
 * `suspect_procs`
   Logs if it detects processes with suspiciously high memory
 * `report_full_status`
-  Gets the state from `system_monitor_top` and produces to a backend of choice
-  that implements `system_monitor_callback` behavior.
+  Gets the state from `system_monitor_top` and produces to a backend module
+  that implements the `system_monitor_callback` behavior, selected by binding
+  `callback_mod` in the `system_monitor` application environment to that module.
+  If `callback_mod` is unbound, this monitor is disabled.
   The preconfigured backend is Postgres and is implemented via `system_monitor_pg`.
 
 `system_monitor_pg` allows for Postgres being temporary down by storing the stats in its own internal buffer.

--- a/src/system_monitor_callback.erl
+++ b/src/system_monitor_callback.erl
@@ -19,6 +19,7 @@
 -export([ start/0
         , stop/0
         , produce/2
+        , is_configured/0
         ]).
 
 -include_lib("system_monitor/include/system_monitor.hrl").
@@ -38,4 +39,7 @@ produce(Type, Events) ->
 
 -compile({inline, [get_callback_mod/0]}).
 get_callback_mod() ->
-  application:get_env(?APP, callback_mod, system_monitor_pg).
+  application:get_env(?APP, callback_mod, undefined).
+
+is_configured() ->
+  get_callback_mod() =/= undefined.


### PR DESCRIPTION
The report_full_status monitor callback_mod defaults to system_monitor_pg, which depends on having a working epgsql configuration. This may not be the case in local development environments, where it leads to endless crashes.

Make the report_full_status monitor require explicit configuration of callback_mod.