### PR TITLE
Keep data that is never updated in proc_info to reduce work

### DIFF
--- a/include/system_monitor.hrl
+++ b/include/system_monitor.hrl
@@ -25,6 +25,9 @@
 
 -record(pid_info,
         { pid                 :: pid()
+        , initial_call        :: mfa() | undefined
+        , registered_name     :: atom() | []
+        , current_function    :: mfa() | undefined
         , reductions          :: integer()
         , dreductions         :: number() | undefined
         , memory              :: integer()


### PR DESCRIPTION
proc_info is reused between ticks so that we do not have to fetch all
data for each tick. registered name, initial call, group leader is
considered static.