### PR TITLE
Support for sending event data to external source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2.2.0] - 2021-11-05
 
 Added support for configuring a module to use to send system_monitor events to
-an external source.
+an external destination.
 
 ## [2.1.0] - 2021-10-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - yyyy-mm-dd
 
+## [2.2.0] - 2021-11-05
+
+Added support for configuring a module to use to send system_monitor events to
+an external source.
+
 ## [2.1.0] - 2021-10-20
 
 Data format of system\_monitor\_top is changed to keep static data between

--- a/src/system_monitor_events.erl
+++ b/src/system_monitor_events.erl
@@ -65,6 +65,10 @@ handle_info({monitor, PidOrPort, EventKind, Info}, State) ->
       , [EventKind, PidOrPort, InfoTxt, ReferenceData]
       , #{domain => [system_monitor]}
       ),
+  case application:get_env(?APP, external_monitoring) of
+    {ok, Mod} -> Mod:system_monitor_event(EventKind, Info);
+    undefined -> ok
+  end,
   {noreply, State};
 handle_info(_Info, State) ->
   {noreply, State}.


### PR DESCRIPTION
This PR adds support to configure a module to be used for sending system monitor events. If the environment variable is undefined it does nothing, and if it is defined it will use the defined module to make a function call.