### PR TITLE
avoid badrecord error in delta/3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - yyyy-mm-dd
 
+## [2.2.1] - 2022-09-12
+
+Fixed a bug which could cause badrecord errors in system\_monitor\_top.
+
 ## [2.2.0] - 2021-11-05
 
 Added support for configuring a module to use to send system_monitor events to

--- a/src/system_monitor_top.erl
+++ b/src/system_monitor_top.erl
@@ -549,8 +549,13 @@ calc_deltas(Old, Pids, Acc, Dt) ->
       Delta = delta(undefined, pid_info_new(P2), Dt),
       calc_deltas(Old, PidsT, [Delta|Acc], Dt);
      P1 =:= P2 -> %% We already have record of P2
-      Delta = delta(PI1, pid_info_update(PI1), Dt),
-      calc_deltas(OldT, PidsT, [Delta|Acc], Dt)
+      case pid_info_update(PI1) of
+        undefined -> % P1 just terminated
+          calc_deltas(OldT, PidsT, Acc, Dt);
+        PI2 ->
+          Delta = delta(PI1, PI2, Dt),
+          calc_deltas(OldT, PidsT, [Delta|Acc], Dt)
+      end
   end.
 
 -spec top_to_list(top()) -> [#pid_info{}].


### PR DESCRIPTION
It's possible for a previously recorded Pid to terminate between the call to `processes/0` on line 207 and the call to `pid_info_update/1` on line 552. In this case `pid_info_update/1` returns `undefined` which crashes `delta/3`:
```
== 9-Sep-2022::14:39:35 == ERROR REPORT - crash_report <0.374.0>
[[{initial_call,{system_monitor_top,init,['Argument__1']}},
  {pid,<0.374.0>},
  {registered_name,system_monitor_top},
  {error_info,
      {error,
          {badrecord,pid_info},
          [{system_monitor_top,delta,3,
               [{file,
                    ".../system_monitor/src/system_monitor_top.erl"},
                {line,569}]},
           {system_monitor_top,calc_deltas,4,
               [{file,
                    ".../system_monitor/src/system_monitor_top.erl"},
                {line,552}]},
           {system_monitor_top,calc_deltas,3,
               [{file,
                    ".../system_monitor/src/system_monitor_top.erl"},
                {line,528}]},
           {system_monitor_top,handle_info,2,
               [{file,
                    ".../system_monitor/src/system_monitor_top.erl"},
                {line,209}]},
           {gen_server,try_dispatch,4,[{file,"gen_server.erl"},{line,689}]},
           {gen_server,handle_msg,6,[{file,"gen_server.erl"},{line,765}]},
           {proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,226}]}]}},
```
Fixed by checking the return from `pid_info_update/1` before calling `delta/3`.