### PR TITLE
Do not query memory usage of processes that have huge message queues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - yyyy-mm-dd
 
+Do not query memory usage of processes that have huge message queues.
+
 ## [2.2.1] - 2022-09-12
 
 Fixed a bug which could cause badrecord errors in system\_monitor\_top.

--- a/src/system_monitor.app.src
+++ b/src/system_monitor.app.src
@@ -71,5 +71,8 @@
     , {suspect_procs_max_memory, 524288000} %% 500 MB
     , {suspect_procs_max_message_queue_len, 5000}
     , {suspect_procs_max_total_heap_size, 524288000} %% 500 MB
+
+      %% Don't query memory if message_queue_len is longer than this:
+    , {mql_limit_for_memory, 100000}
     ]}
  ]}.


### PR DESCRIPTION
process_info(_, messages) can be very expensive, not only for system_monitor itself but also for the monitored process, so avoid calling it when MQL is huge.

It's not easy to skip including a value for messages in the final output (the field is marked non-nullable) so I opted to set the value to zero when we skipped fetching it.