### PR TITLE
Sort deltas before returning

### DIFF
--- a/src/system_monitor_top.erl
+++ b/src/system_monitor_top.erl
@@ -564,10 +564,10 @@ calc_deltas(OldData, Pids, Dt) ->
   when PIL :: [#pid_info{}].
 calc_deltas([], New, Acc, Dt) ->
   %% The rest of the processess are new
-  [delta(undefined, pid_info_new(Pid), Dt) || Pid <- New] ++ Acc;
+  lists:sort([delta(undefined, pid_info_new(Pid), Dt) || Pid <- New] ++ Acc);
 calc_deltas(_Old, [], Acc, _) ->
   %% The rest of the processes have terminated
-  Acc;
+  lists:sort(Acc);
 calc_deltas(Old, Pids, Acc, Dt) ->
   [PI1 = #pid_info{pid = P1} | OldT] = Old,
   [P2 | PidsT] = Pids,


### PR DESCRIPTION
- The original author of system_monitor_top:calc_deltas/4 intended an implementation similar to orddict:merge/3 in order to truly be able to treat the [pid_info{}] and processes/0 lists the same, the old [pid_info{}] list must always come in a sorted fashion