### PR TITLE
Do not divide MaxProcs by 5

### DIFF
--- a/src/system_monitor.erl
+++ b/src/system_monitor.erl
@@ -177,7 +177,7 @@ monitors() ->
 check_process_count() ->
   {ok, MaxProcs} = application:get_env(?APP, top_max_procs),
   case erlang:system_info(process_count) of
-    Count when Count > MaxProcs div 5 ->
+    Count when Count > MaxProcs ->
       ?LOG_WARNING(
           "Abnormal process count (~p).~n"
           , [Count]


### PR DESCRIPTION
It is unclear why this was ever done to begin with, and it is super-confusing.