### PR TITLE
Codify the status quo that monitors are not run at terminate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - yyyy-mm-dd
 
+## [2.3.1] - 2025-11-28
+
+Codify the status quo that monitors are not run at terminate.
+
 ## [2.3.0] - 2025-11-25
 
 Update proper

--- a/src/system_monitor.erl
+++ b/src/system_monitor.erl
@@ -124,10 +124,8 @@ handle_info(_Info, State) ->
   {noreply, State}.
 
 -spec terminate(term(), #state{}) -> any().
-terminate(_Reason, State) ->
-  %% Possibly, one last check.
-  [apply(?MODULE, Monitor, []) ||
-    {Monitor, true, _TicksReset, _Ticks} <- State#state.monitors].
+terminate(_Reason, _State) ->
+  ok.
 
 %%==============================================================================
 %% Internal functions
@@ -144,8 +142,7 @@ init_monitors() ->
 %%------------------------------------------------------------------------------
 %% @doc Returns the list of monitors. The format is
 %%      {FunctionName, RunMonitorAtTerminate, NumberOfTicks}.
-%%      RunMonitorAtTerminate determines whether the monitor is to be run in
-%%      the terminate gen_server callback.
+%%      RunMonitorAtTerminate is ignored.
 %%      ... and NumberOfTicks is the number of ticks between invocations of
 %%      the monitor in question. So, if NumberOfTicks is 3600, the monitor is
 %%      to be run once every hour, as there is a tick every second.


### PR DESCRIPTION
Due to a type mismatch the terminate/2 callback doesn't run any monitors. This type mismatch has been there ever since the initial commit. Fixing the type mismatch would change behaviour in potentially incompatible ways, so I elected to codify the status quo instead.

If someone wants this functionality they'll need to bump major version.

Fixes #31 